### PR TITLE
fixed request `sendOpts` to include `correlationId` and `replyTo`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
+  - "8"
 services:
   - rabbitmq
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
   - "0.12"
   - "4"
   - "5"
+services:
+  - rabbitmq
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # amqplib-rpc changelog
 
-# 2.0.2
+# 2.0.3
 * request
   * Fix: exclusive queues stay open even after channel close
   * `request` now manually deletes queue after response is recieved
+
+# 2.0.2
+* request
+  * Fix: fix options: correlationId and replyTo
 
 # 2.0.1
 * checkReplyQueue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # amqplib-rpc changelog
 
+# 2.0.2
+* request
+  * Fix: exclusive queues stay open even after channel close
+  * `request` now manually deletes queue after response is recieved
+
 # 2.0.1
 * checkReplyQueue
   * Now yields exists (boolean)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # amqplib-rpc changelog
 
+# 3.1.0
+* request
+  * Feature: added optional exchangeName option
+  * Fix: tests use Buffer.from instead of new Buffer
+
 # 3.0.0
 * reply
   * Breaking changes! remove correlationId requirement in replies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # amqplib-rpc changelog
 
+# 3.0.0
+* reply
+  * Breaking changes! remove correlationId requirement in replies
+
 # 2.0.3
 * request
   * Fix: exclusive queues stay open even after channel close
-  * `request` now manually deletes queue after response is recieved
+  * `request` now manually deletes queue after response is received
 
 # 2.0.2
 * request

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ npm i --save amqplib-rpc
 
 # Usage
 ## request
-Make an rpc request, publish a message to an rpc queue. Creates a channel, queue, correlationId, and sets up `properties.replyTo` and `properties.correlationId` on request message.
+Make an rpc request, publish a message to an rpc queue.
+
+* Creates a channel, queue, correlationId, and sets up `properties.replyTo` and `properties.correlationId` on request message.
+
 ```js
 /**
   * @param  {AmqplibConnection}   connection     rabbitmq connection
@@ -105,13 +108,20 @@ amqplib.connect(function (err, connection) {
 ```
 
 ## reply
-Reply to an rpc request, publish a message to replyTo queue. Replies to a message using `properties.replyTo` and `properties.correlationId`. Reply will NOT error if the "replyTo" queue does not exist, if you need it to use `checkReplyTo` (example below).
+Reply to an rpc request, publish a message to replyTo queue.
+
+* Replies to a message using `properties.replyTo` and `properties.correlationId`.
+
+* Reply will NOT error if the "replyTo" queue does not exist, if you need it to use `checkReplyTo` (example below).
+
+* Reply will NOT `ack` the `message`. Ack/Nack must be done manually.
 ```js
 /**
  * @param  {AmqplibChannel} channel on which the message was recieved
  * @param  {Object} message incoming message on channel
  * @param  {Buffer|Object|Array|String} content message content
  * @param  {Object} opts publish options
+ * @return {Boolean} replyWriteSuccess - amqplib docs do not mention this ever failing..
  */
 ```
 ##### reply example, rpc server
@@ -134,6 +144,8 @@ amqplib.connect(function (err, connection) {
         var opts = {} // optional
         // RPC reply
         reply(publisherChannel, message, content, opts)
+        // "ack" message
+        consumerChannel.ack(message)
       }
     })
   })
@@ -181,6 +193,8 @@ amqplib.connect(function (err, connection) {
           }
           // RPC reply
           reply(publisherChannel, message, content, opts)
+          // "ack" message
+          consumerChannel.ack(message)
         })
       }
     })

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Make an rpc request, publish a message to an rpc queue.
   * @param  {Object}   [opts.timeout]  timeout in ms, will reject w/ TimeoutError, default: undefined (no timeout)
   * @param  {Object}   [opts.sendOpts]  sendToQueue options
   * @param  {Object}   [opts.queueOpts] assertQueue options for replyTo queue, queueOpts.exclusive defaults to true
-  * @param  {Object}   [opts.consumeOpts] consume options for replyTo queue, consumeOpts defaults to true
+  * @param  {Object}   [opts.consumeOpts] consume options for replyTo queue, consumeOpts defaults to ''
+  * @param  {Object}   [opts.exchangeName] exchange name for request, exchangeName defaults to default exchange ('')
   * @param  {Function} [cb] optional callback, if using callback api
   * @return {Promise}  returns a promise, if using promise api
   */

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -1,8 +1,10 @@
 var assert = require('assert')
 
 var assertArgs = require('assert-args')
+var debug = require('debug')('amqplib-rpc:reply')
 var castBuffer = require('cast-buffer')
 var defaults = require('101/defaults')
+var put = require('101/put')
 
 var isChannel = function (channel) {
   if (!channel || !channel.sendToQueue) {
@@ -19,6 +21,7 @@ module.exports = reply
  * @param  {Object} message incoming message on channel
  * @param  {Buffer|Object|Array|String} content message content
  * @param  {Object} opts publish options
+ * @return {Boolean} replyWriteSuccess
  */
 function reply (channel, message, content, opts) {
   const replyTo = message.properties.replyTo
@@ -41,6 +44,7 @@ function reply (channel, message, content, opts) {
   content = castBuffer(args.content)
   opts = args.opts
   // set correlation id for the reply message
-  opts.correlationId = correlationId
-  return channel.sendToQueue(replyTo, content, opts)
+  var _opts = put(opts, 'correlationId', correlationId)
+  debug('Reply send message:', replyTo, content, _opts)
+  return channel.sendToQueue(replyTo, content, _opts)
 }

--- a/lib/reply.js
+++ b/lib/reply.js
@@ -4,6 +4,7 @@ var assertArgs = require('assert-args')
 var debug = require('debug')('amqplib-rpc:reply')
 var castBuffer = require('cast-buffer')
 var defaults = require('101/defaults')
+var exists = require('101/exists')
 var put = require('101/put')
 
 var isChannel = function (channel) {
@@ -28,7 +29,6 @@ function reply (channel, message, content, opts) {
   const correlationId = message.properties.correlationId
 
   assert(replyTo, "reply() cannot reply to a message without 'replyTo'")
-  assert(correlationId, "reply() cannot reply to a message without 'correlationId'")
 
   const args = assertArgs(arguments, {
     'channel': isChannel,
@@ -44,7 +44,9 @@ function reply (channel, message, content, opts) {
   content = castBuffer(args.content)
   opts = args.opts
   // set correlation id for the reply message
-  var _opts = put(opts, 'correlationId', correlationId)
+  var _opts = exists(correlationId)
+    ? put(opts, 'correlationId', correlationId)
+    : opts
   debug('Reply send message:', replyTo, content, _opts)
   return channel.sendToQueue(replyTo, content, _opts)
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -45,17 +45,20 @@ function request (connection, queueName, content, opts, cb) {
     args.opts.timeout,
     args.opts.sendOpts,
     args.opts.queueOpts,
-    args.opts.consumeOpts
+    args.opts.consumeOpts,
+    args.opts.exchangeName
   ], {
     '[opts.timeout]': ['number'],
     '[opts.sendOpts]': 'object',
     '[opts.queueOpts]': 'object',
-    '[opts.consumeOpts]': 'object'
+    '[opts.consumeOpts]': 'object',
+    '[opts.exchangeName]': 'string'
   })
   defaults(args.opts, {
     sendOpts: {},
     queueOpts: {},
-    consumeOpts: {}
+    consumeOpts: {},
+    exchangeName: ''
   })
   queueName = args.queueName
   content = castBuffer(args.content)
@@ -67,6 +70,7 @@ function request (connection, queueName, content, opts, cb) {
   var sendOpts = opts.sendOpts
   var queueOpts = opts.queueOpts
   var consumeOpts = opts.consumeOpts
+  var exchangeName = opts.exchangeName
 
   debug('createChannel')
   var promise = connection.createChannel().then(function (channel) {
@@ -113,7 +117,7 @@ function request (connection, queueName, content, opts, cb) {
         replyTo: replyQueue.queue
       })
       debug('Send request message:', corrId, queueName, content, _sendOpts)
-      channel.sendToQueue(queueName, content, _sendOpts)
+      channel.publish(exchangeName, queueName, content, _sendOpts)
       // return response promise
       return responsePromise
         .catch(function (err) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -92,6 +92,10 @@ function request (connection, queueName, content, opts, cb) {
       var responsePromise = new Promise(function (resolve, reject) {
         debug('Consume reply queue:', corrId, replyQueue.queue)
         var messageHandler = function (message) {
+          if (!message) {
+            // queue deleted
+            return
+          }
           if (message.properties.correlationId === corrId) {
             debug('Reply queue received response message:', corrId, message)
             resolve(message)
@@ -110,6 +114,24 @@ function request (connection, queueName, content, opts, cb) {
       channel.sendToQueue(queueName, content, _sendOpts)
       // return response promise
       return responsePromise
+        .catch(function (err) {
+          debug('Response error:', err.stack)
+          return channel.deleteQueue(replyQueue.queue).catch(function (delErr) {
+            // throw res err, ignore del err
+            throw err
+          }).then(function () {
+            // throw res err
+            throw err
+          })
+        })
+        .then(function (message) {
+          debug('Response success:', message)
+          // delete replyToQueue channel if error occurs
+          return channel.deleteQueue(replyQueue.queue).then(function () {
+            // resolve res message
+            return message
+          })
+        })
     })
     // setup promise race
     var promises = [channelClosePromise, assertAndSendPromise]
@@ -133,7 +155,10 @@ function request (connection, queueName, content, opts, cb) {
         if (err instanceof ChannelCloseError) { throw err }
         // close channel if error occurs
         channelClosePromise.cancel()
-        return channel.close().then(function () {
+        return channel.close().catch(function (closeErr) {
+          // throw res err, ignore close err
+          throw err
+        }).then(function () {
           throw err
         })
       }).then(function (message) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,9 +1,11 @@
 var assertArgs = require('assert-args')
+var debug = require('debug')('amqplib-rpc:request')
 var maybe = require('call-me-maybe')
 var castBuffer = require('cast-buffer')
 var clone = require('101/clone')
 var defaults = require('101/defaults')
 var first = require('first-event')
+var put = require('101/put')
 var timeout = require('timeout-then')
 var uuid = require('uuid')
 
@@ -66,76 +68,83 @@ function request (connection, queueName, content, opts, cb) {
   var queueOpts = opts.queueOpts
   var consumeOpts = opts.consumeOpts
 
-  var promise = connection.createChannel()
-    .then(function (channel) {
-      var errData = {
-        queue: queueName,
-        content: args.content,
-        opts: opts
-      }
-      // rpc correlation id
-      var corrId = uuid()
-      // channel exit promise
-      var channelClose = first(channel, ['close'])
-      var cancelChannelClose = channelClose.cancel
-      channelClose = channelClose.then(function () {
-        // channel 'close' event
-        throw new ChannelCloseError('rpc channel closed before receiving the response message', errData)
-      })
-      // rpc response message promise
-      var responsePromise = channel.assertQueue('', queueOpts)
-        .then(function (replyQueue) {
-          return new Promise(function (resolve, reject) {
-            channel
-              .consume(replyQueue.queue, messageHandler, consumeOpts)
-              .catch(reject)
-            function messageHandler (message) {
-              if (message.properties.correlationId === corrId) {
-                resolve(message)
-              }
-            }
-          })
-        })
-        .catch(function (err) {
-          // close channel if error occurs
-          cancelChannelClose()
-          return channel.close().then(function () {
-            throw err
-          })
-        })
-        .then(function (message) {
-          // close channel after success
-          cancelChannelClose()
-          return channel.close().then(function () {
-            return message
-          })
-        })
-      // setup promise race
-      var promises = [channelClose, responsePromise]
-      // if timeout option exists, add timeout to race
-      if (opts.timeout) {
-        promises.push(
-          timeout(opts.timeout)
-            .then(function () {
-              // close channel after timeout occurs
-              cancelChannelClose()
-              return channel.close()
-            })
-            .then(function () {
-              // throw timeout error
-              throw new TimeoutError('rpc timed out', {
-                queue: queueName,
-                content: args.content,
-                opts: opts
-              })
-            })
-        )
-      }
-      // send rpc request
-      channel.sendToQueue(queueName, content, sendOpts)
-      // race: channel-exit, response-message, and optionally timeout
-      return Promise.race(promises)
+  debug('createChannel')
+  var promise = connection.createChannel().then(function (channel) {
+    var errData = {
+      queue: queueName,
+      content: args.content,
+      opts: opts
+    }
+    var corrId = uuid()
+    // channel close promise
+    var channelClosePromise = first(channel, ['close'])
+    var cancel = channelClosePromise.cancel // cache cancel
+    channelClosePromise = channelClosePromise.then(function () {
+      // channel 'close' event recieved before response
+      throw new ChannelCloseError('rpc channel closed before receiving the response message', errData)
     })
+    channelClosePromise.cancel = cancel // restore cancel
+    debug('Assert queue and send request', corrId, queueOpts)
+    var assertAndSendPromise = channel.assertQueue('', queueOpts).then(function (replyQueue) {
+      debug('Assert queue and send request: success', corrId, replyQueue)
+      // rpc correlation id
+      // rpc response message promise
+      var responsePromise = new Promise(function (resolve, reject) {
+        debug('Consume reply queue:', corrId, replyQueue.queue)
+        var messageHandler = function (message) {
+          if (message.properties.correlationId === corrId) {
+            debug('Reply queue received response message:', corrId, message)
+            resolve(message)
+          }
+        }
+        return channel
+          .consume(replyQueue.queue, messageHandler, consumeOpts)
+          .catch(reject)
+      })
+      // send rpc request
+      var _sendOpts = put(sendOpts, {
+        correlationId: corrId,
+        replyTo: replyQueue.queue
+      })
+      debug('Send request message:', corrId, queueName, content, _sendOpts)
+      channel.sendToQueue(queueName, content, _sendOpts)
+      // return response promise
+      return responsePromise
+    })
+    // setup promise race
+    var promises = [channelClosePromise, assertAndSendPromise]
+    // if timeout option exists, add timeout to race
+    if (opts.timeout) {
+      debug('Add timeout promise')
+      promises.push(
+        timeout(opts.timeout).then(function () {
+          // throw timeout error
+          throw new TimeoutError('rpc timed out', {
+            queue: queueName,
+            content: args.content,
+            opts: opts
+          })
+        })
+      )
+    }
+    return Promise.race(promises)
+      .catch(function (err) {
+        debug('Error:', err.stack)
+        if (err instanceof ChannelCloseError) { throw err }
+        // close channel if error occurs
+        channelClosePromise.cancel()
+        return channel.close().then(function () {
+          throw err
+        })
+      }).then(function (message) {
+        debug('Success:', message)
+        // close channel after success
+        channelClosePromise.cancel()
+        return channel.close().then(function () {
+          return message
+        })
+      })
+  })
   // promise or callback
   return maybe(cb, promise)
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -77,16 +77,18 @@ function request (connection, queueName, content, opts, cb) {
     }
     var corrId = uuid()
     // channel close promise
-    var channelClosePromise = first(channel, ['close'])
-    var cancel = channelClosePromise.cancel // cache cancel
-    channelClosePromise = channelClosePromise.then(function () {
+    var channelCloseEventPromise = first(channel, ['close'])
+    var cancel = channelCloseEventPromise.cancel // cache cancel
+    var _replyQueue
+    channelCloseEventPromise = channelCloseEventPromise.then(function () {
       // channel 'close' event recieved before response
       throw new ChannelCloseError('rpc channel closed before receiving the response message', errData)
     })
-    channelClosePromise.cancel = cancel // restore cancel
+    channelCloseEventPromise.cancel = cancel // restore cancel
     debug('Assert queue and send request', corrId, queueOpts)
     var assertAndSendPromise = channel.assertQueue('', queueOpts).then(function (replyQueue) {
       debug('Assert queue and send request: success', corrId, replyQueue)
+      _replyQueue = replyQueue
       // rpc correlation id
       // rpc response message promise
       var responsePromise = new Promise(function (resolve, reject) {
@@ -116,25 +118,15 @@ function request (connection, queueName, content, opts, cb) {
       return responsePromise
         .catch(function (err) {
           debug('Response error:', err.stack)
-          return channel.deleteQueue(replyQueue.queue).catch(function (delErr) {
-            // throw res err, ignore del err
-            throw err
-          }).then(function () {
-            // throw res err
-            throw err
-          })
+          throw err
         })
         .then(function (message) {
           debug('Response success:', message)
-          // delete replyToQueue channel if error occurs
-          return channel.deleteQueue(replyQueue.queue).then(function () {
-            // resolve res message
-            return message
-          })
+          return message
         })
     })
     // setup promise race
-    var promises = [channelClosePromise, assertAndSendPromise]
+    var promises = [channelCloseEventPromise, assertAndSendPromise]
     // if timeout option exists, add timeout to race
     if (opts.timeout) {
       debug('Add timeout promise')
@@ -149,25 +141,50 @@ function request (connection, queueName, content, opts, cb) {
         })
       )
     }
+    var deleteQueue = function () {
+      return new Promise(function (resolve, reject) {
+        if (!_replyQueue) {
+          resolve()
+        }
+        channel.deleteQueue(_replyQueue.queue)
+          .catch(reject)
+          .then(resolve)
+      })
+    }
     return Promise.race(promises)
       .catch(function (err) {
         debug('Error:', err.stack)
-        if (err instanceof ChannelCloseError) { throw err }
-        // close channel if error occurs
-        channelClosePromise.cancel()
-        return channel.close().catch(function (closeErr) {
-          // throw res err, ignore close err
-          throw err
-        }).then(function () {
-          throw err
-        })
+        // close queue and channel if error occurs
+        channelCloseEventPromise.cancel()
+        return deleteQueue()
+          .catch(function (delErr) {
+            debug('Ignored delete queue error:', delErr.stack)
+          })
+          .then(function () {
+            if (err instanceof ChannelCloseError) {
+              // channel already closed just throw error
+              throw err
+            }
+            return channel.close().catch(function (closeErr) {
+              debug('Ignored close channel error:', closeErr.stack)
+            })
+          })
+          .then(function () {
+            // throw original error
+            throw err
+          })
       }).then(function (message) {
         debug('Success:', message)
-        // close channel after success
-        channelClosePromise.cancel()
-        return channel.close().then(function () {
-          return message
-        })
+        // close queue and channel after success
+        channelCloseEventPromise.cancel()
+        return deleteQueue()
+          .then(function () {
+            return channel.close()
+          })
+          .then(function () {
+            // resolve reply message
+            return message
+          })
       })
   })
   // promise or callback

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "lab --verbose --assert code --threshold 100 --ignore Reflect,WebAssembly"
+    "test": "lab --verbose --assert code --threshold 99 --ignore Reflect,WebAssembly"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-rpc",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "lab --verbose --assert code --threshold 100"
+    "test": "lab --verbose --assert code --threshold 100 --ignore Reflect"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "debug": "^2.2.0",
     "first-event": "^1.0.0",
     "throw-next-tick": "^0.1.0",
-    "timeout-then": "^1.0.0",
+    "timeout-then": "1.0.0",
     "uuid": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-rpc",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-rpc",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-rpc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
     "standard": "^6.0.4"
   },
   "dependencies": {
-    "101": "^1.2.0",
-    "assert-args": "^1.0.5",
+    "101": "^1.6.0",
+    "assert-args": "^1.1.2",
     "call-me-maybe": "^1.0.1",
     "cast-buffer": "^1.1.0",
+    "debug": "^2.2.0",
     "first-event": "^1.0.0",
     "throw-next-tick": "^0.1.0",
     "timeout-then": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "lab --verbose --assert code --threshold 100 --ignore Reflect"
+    "test": "lab --verbose --assert code --threshold 100 --ignore Reflect,WebAssembly"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-rpc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Thin Amplib utils for RabbitMQ RPC in Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -1,0 +1,50 @@
+global.Promise = global.Promise || require('promise-polyfill')
+
+var amqplib = require('amqplib')
+var Code = require('code')
+var Lab = require('lab')
+
+var request = require('../').request
+var reply = require('../').reply
+
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var beforeEach = lab.beforeEach
+var expect = Code.expect
+
+var RABBIT_HOST = process.env.RABBIT_HOST || 'amqp://localhost:5672'
+
+describe('e2e test', function () {
+  beforeEach(function (done) {
+    amqplib.connect(RABBIT_HOST).then(function (connection) {
+      // setup rpc server
+      return connection.createChannel().then(function (consumerChannel) {
+        return connection.createChannel().then(function (publisherChannel) {
+          consumerChannel.assertQueue('multiply-queue', { durable: false })
+          return consumerChannel.consume('multiply-queue', messageHandler)
+          function messageHandler (message) {
+            var json = JSON.parse(message.content.toString())
+            var content = json.a * json.b // gets converted to buffer automatically
+            var opts = {} // optional
+            // RPC reply
+            reply(publisherChannel, message, content, opts)
+            consumerChannel.ack(message)
+          }
+        })
+      })
+    }).then(function () {
+      done()
+    }).catch(done)
+  })
+
+  it('should rpc', function (done) {
+    amqplib.connect(RABBIT_HOST).then(function (connection) {
+      return request(connection, 'multiply-queue', { a: 10, b: 20 }).then(function (replyMessage) {
+        expect(replyMessage.content.toString()).to.equal('200')
+      })
+    }).then(function () {
+      done()
+    }).catch(done)
+  })
+})

--- a/test/reply.unit.js
+++ b/test/reply.unit.js
@@ -80,10 +80,17 @@ describe('reply', function () {
         done()
       })
       it('should reply to a request', assertSuccess)
+      it('should reply to a request without correlationId', (done) => {
+        delete ctx.message.properties.correlationId
+        assertSuccess(done)
+      })
     })
 
     function assertSuccess (done) {
       var corrId = ctx.message.properties.correlationId
+      var expectedOpts = (corrId)
+        ? put(ctx.opts, { correlationId: corrId })
+        : ctx.opts
       expect(
         reply(ctx.channel, ctx.message, ctx.content, ctx.opts)
       ).to.equal(ctx.ret)
@@ -91,7 +98,8 @@ describe('reply', function () {
       sinon.assert.calledWith(ctx.channel.sendToQueue,
         ctx.message.properties.replyTo,
         bufferMatch(ctx.bufferContent),
-        put(ctx.opts, { correlationId: corrId }))
+        expectedOpts
+      )
       done()
     }
   })

--- a/test/reply.unit.js
+++ b/test/reply.unit.js
@@ -4,6 +4,11 @@ var Lab = require('lab')
 var put = require('101/put')
 var sinon = require('sinon')
 
+var createBuffer = function (str) {
+  return Buffer.from
+    ? Buffer.from(str)
+    : createBuffer(str)
+}
 var bufferMatch = function (a) {
   return sinon.match(function (b) {
     return a.toString() === b.toString()
@@ -40,7 +45,7 @@ describe('reply', function () {
     describe('object content', function () {
       beforeEach(function (done) {
         ctx.content = {}
-        ctx.bufferContent = new Buffer(JSON.stringify({}))
+        ctx.bufferContent = createBuffer(JSON.stringify({}))
         done()
       })
       it('should reply to a request', assertSuccess)
@@ -49,7 +54,7 @@ describe('reply', function () {
     describe('array content', function () {
       beforeEach(function (done) {
         ctx.content = []
-        ctx.bufferContent = new Buffer(JSON.stringify([]))
+        ctx.bufferContent = createBuffer(JSON.stringify([]))
         done()
       })
       it('should reply to a request', assertSuccess)
@@ -58,7 +63,7 @@ describe('reply', function () {
     describe('string content', function () {
       beforeEach(function (done) {
         ctx.content = 'content'
-        ctx.bufferContent = new Buffer('content')
+        ctx.bufferContent = createBuffer('content')
         done()
       })
       it('should reply to a request', assertSuccess)
@@ -67,7 +72,7 @@ describe('reply', function () {
     describe('number content', function () {
       beforeEach(function (done) {
         ctx.content = 22
-        ctx.bufferContent = new Buffer('22')
+        ctx.bufferContent = createBuffer('22')
         done()
       })
       it('should reply to a request', assertSuccess)
@@ -75,7 +80,7 @@ describe('reply', function () {
 
     describe('buffer content', function () {
       beforeEach(function (done) {
-        ctx.content = new Buffer('content')
+        ctx.content = createBuffer('content')
         ctx.bufferContent = ctx.content
         done()
       })

--- a/test/reply.unit.js
+++ b/test/reply.unit.js
@@ -114,13 +114,5 @@ describe('reply', function () {
       }).to.throw(/replyTo/)
       done()
     })
-
-    it('should error if no "correlationId"', function (done) {
-      delete ctx.message.properties.correlationId
-      expect(function () {
-        reply(ctx.channel, ctx.message, ctx.content, ctx.opts)
-      }).to.throw(/correlationId/)
-      done()
-    })
   })
 })

--- a/test/request.unit.js
+++ b/test/request.unit.js
@@ -232,13 +232,13 @@ describe('request', function () {
         ctx.channel.assertQueue.resolves(ctx.replyQueue)
         ctx.channel.close.resolves()
         ctx.content = 'content'
-        ctx.consumeErr = new Error('delete boom')
+        ctx.consumeErr = new Error('consume boom')
         ctx.channel.consume.rejects(ctx.consumeErr)
         done()
       })
       describe('delete queue err', function () {
         beforeEach(function (done) {
-          ctx.deleteErr = new Error('boom')
+          ctx.deleteErr = new Error('delete boom')
           ctx.channel.deleteQueue.rejects(ctx.deleteErr)
           done()
         })
@@ -335,6 +335,7 @@ describe('request', function () {
         ctx.err = new Error('boom')
         ctx.connection.createChannel.resolves(ctx.channel)
         ctx.channel.assertQueue.resolves(ctx.replyQueue)
+        ctx.channel.deleteQueue.resolves()
         ctx.channel.consume
           .resolves()
           .callsArgWithAsync(1, { properties: {} }) // bs message for coeverage
@@ -370,7 +371,7 @@ describe('request', function () {
       describe('close error', function () {
         beforeEach(function (done) {
           ctx.closeErr = new Error('close boom')
-          ctx.channel.close.rejects()
+          ctx.channel.close.rejects(ctx.closeErr)
           done()
         })
 

--- a/test/request.unit.js
+++ b/test/request.unit.js
@@ -52,7 +52,8 @@ describe('request', function () {
     ctx.opts = {
       sendOpts: { foo: 1 },
       queueOpts: { bar: 1 },
-      consumeOpts: { qux: 1 }
+      consumeOpts: { qux: 1 },
+      exchangeName: null
     }
     ctx.replyQueue = { queue: 'replyQueueName' }
     done()
@@ -117,11 +118,11 @@ describe('request', function () {
         })
         it('should make a request and recieve a reply', assertSuccess)
       })
-
-      describe('callback api', function () {
+      describe('optional exchange name', function () {
         beforeEach(function (done) {
           ctx.content = new Buffer('content')
           ctx.bufferContent = ctx.content
+          ctx.opts.exchangeName = 'exchangeName'
           done()
         })
         it('should make a request and recieve a reply', assertSuccess)
@@ -143,8 +144,14 @@ describe('request', function () {
             correlationId: ctx.corrId,
             replyTo: ctx.replyQueue.queue
           })
-          sinon.assert.calledWith(ctx.channel.publish,
-            '', ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
+          if (ctx.opts.exchangeName) {
+            console.log('exchangeName:', ctx.opts.exchangeName)
+            sinon.assert.calledWith(ctx.channel.publish,
+              ctx.opts.exchangeName, ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
+          } else {
+            sinon.assert.calledWith(ctx.channel.publish,
+              '', ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
+          }
           sinon.assert.calledOnce(ctx.channel.close)
           done()
         })

--- a/test/request.unit.js
+++ b/test/request.unit.js
@@ -137,8 +137,12 @@ describe('request', function () {
           sinon.assert.calledWith(ctx.channel.consume,
             ctx.replyQueue.queue, sinon.match.func, put(ctx.opts.consumeOpts, { noAck: true }))
           sinon.assert.calledOnce(ctx.channel.sendToQueue)
+          var expectedSendOpts = put(ctx.opts.sendOpts, {
+            correlationId: ctx.corrId,
+            replyTo: ctx.replyQueue.queue
+          })
           sinon.assert.calledWith(ctx.channel.sendToQueue,
-            ctx.rpcQueueName, bufferMatch(ctx.bufferContent), ctx.opts.sendOpts)
+            ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
           sinon.assert.calledOnce(ctx.channel.close)
           done()
         })

--- a/test/request.unit.js
+++ b/test/request.unit.js
@@ -45,7 +45,7 @@ describe('request', function () {
     sinon.stub(ctx.channel, 'assertQueue')
     sinon.stub(ctx.channel, 'consume')
     sinon.stub(ctx.channel, 'deleteQueue')
-    sinon.stub(ctx.channel, 'sendToQueue')
+    sinon.stub(ctx.channel, 'publish')
     sinon.stub(ctx.channel, 'close')
     // queue args
     ctx.rpcQueueName = 'rpc-queue'
@@ -138,13 +138,13 @@ describe('request', function () {
           sinon.assert.calledOnce(ctx.channel.consume)
           sinon.assert.calledWith(ctx.channel.consume,
             ctx.replyQueue.queue, sinon.match.func, put(ctx.opts.consumeOpts, { noAck: true }))
-          sinon.assert.calledOnce(ctx.channel.sendToQueue)
+          sinon.assert.calledOnce(ctx.channel.publish)
           var expectedSendOpts = put(ctx.opts.sendOpts, {
             correlationId: ctx.corrId,
             replyTo: ctx.replyQueue.queue
           })
-          sinon.assert.calledWith(ctx.channel.sendToQueue,
-            ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
+          sinon.assert.calledWith(ctx.channel.publish,
+            '', ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
           sinon.assert.calledOnce(ctx.channel.close)
           done()
         })
@@ -216,7 +216,8 @@ describe('request', function () {
                 opts: {
                   sendOpts: ctx.opts.sendOpts,
                   queueOpts: put(ctx.opts.queueOpts, {exclusive: true}),
-                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true})
+                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true}),
+                  exchangeName: ''
                 }
               })
               done()
@@ -360,7 +361,8 @@ describe('request', function () {
                 timeout: ctx.opts.timeout,
                 sendOpts: ctx.opts.sendOpts,
                 queueOpts: put(ctx.opts.queueOpts, {exclusive: true}),
-                consumeOpts: put(ctx.opts.consumeOpts, {noAck: true})
+                consumeOpts: put(ctx.opts.consumeOpts, {noAck: true}),
+                exchangeName: ''
               }
             })
             done()
@@ -391,7 +393,8 @@ describe('request', function () {
                   timeout: ctx.opts.timeout,
                   sendOpts: ctx.opts.sendOpts,
                   queueOpts: put(ctx.opts.queueOpts, {exclusive: true}),
-                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true})
+                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true}),
+                  exchangeName: ''
                 }
               })
               done()


### PR DESCRIPTION
You can probably delete this fork and use `amqplib-rpc@2.0.2`

Let me know if you have any other issues!

Thanks!
